### PR TITLE
Fix remote_pending_changes referenced before assignment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: python
 cache:
   pip: true
-  directories:
-    - .tox/
-before_cache:
-  # We don't currently use any secure environment variables, but just in case, and also to avoid caches that grow forever, remove log dirs.
-  - rm -rf .tox/*/log .tox/log .tox/*/local/log
-  # For some reason (because we build the manpages toxenv inside docker, maybe?), caching .tox/manpages leads to failing itest_% builds.
-  - rm -rf .tox/manpages
 services:
     - docker
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-cache:
-  pip: true
 services:
     - docker
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: python
+cache:
+  pip: true
+  directories:
+    - .tox/
+    - $HOME/.cache/pip-faster/
+    - $HOME/.cache/pre-commit/
+before_cache:
+    - rm -rf .tox/*/log .tox/log .tox/*/local/log
+    - rm -rf .tox/manpages
 services:
     - docker
 python:

--- a/docs/cmdline.rst
+++ b/docs/cmdline.rst
@@ -57,6 +57,16 @@ Command line
 .. autoprogram:: syncr_backend.bin.update_drop:parser()
     :prog: update_drop
 
+.. _new_version:
+
+.. autoprogram:: syncr_backend.bin.new_version:parser()
+    :prog: new_version
+
+.. _check_for_updates:
+
+.. autoprogram:: syncr_backend.bin.check_for_updates:parser()
+    :prog: check_for_updates
+
 .. note::
-    Specifying ``--save-dir`` and ``--drop_id`` may have unexpected results if
-    they do not match
+    Specifying ``--save-dir`` and ``--drop_id`` in the three previous commands
+    may have unexpected results if they do not match

--- a/syncr_backend/network/handle_frontend.py
+++ b/syncr_backend/network/handle_frontend.py
@@ -304,7 +304,7 @@ async def _handle_selected_drop(
         drop_id = crypto_util.b64decode(request['drop_id'])
         md = await get_drop_metadata(drop_id, [])
         drop = await drop_metadata_to_response(md)
-        remote_pending_changes = {}
+        remote_pending_changes = {}  # type: Dict[str, List[str]]
         if get_pending_changes:
             file_update_status = await check_for_changes(drop_id)
             if file_update_status is None:
@@ -319,7 +319,6 @@ async def _handle_selected_drop(
 
             new_metadata, new_version_available = \
                 await check_for_update(drop_id)
-            remote_pending_changes = {}  # type: Dict[str, List[str]]
             if new_version_available:
                 remote_update_status = await find_changes_in_new_version(
                     drop_id, new_metadata,

--- a/syncr_backend/network/handle_frontend.py
+++ b/syncr_backend/network/handle_frontend.py
@@ -240,6 +240,7 @@ async def _handle_selected_drop(
         drop_id = crypto_util.b64decode(request['drop_id'])
         md = await get_drop_metadata(drop_id, [])
         drop = await drop_metadata_to_response(md)
+        remote_pending_changes = {}
         if get_pending_changes:
             file_update_status = await check_for_changes(drop_id)
             if file_update_status is None:


### PR DESCRIPTION
```
2018-05-05 11:51:47,336 - syncr_backend.network.handle_frontend - ERROR - Error handling request: local variable 'remote_pending_changes' referenced before assignment
Traceback (most recent call last):
  File "/home/matthew/projects/5yncr/backend/syncr_backend/network/handle_frontend.py", line 85, in handle_frontend_request
    await handle_function(request, conn)
  File "/home/matthew/projects/5yncr/backend/syncr_backend/network/handle_frontend.py", line 210, in handle_get_selected_drop
    await _handle_selected_drop(False, request, conn)
  File "/home/matthew/projects/5yncr/backend/syncr_backend/network/handle_frontend.py", line 286, in _handle_selected_drop
    'remote_pending_changes': remote_pending_changes,
UnboundLocalError: local variable 'remote_pending_changes' referenced before assignment
```